### PR TITLE
fix(file.js, pwa.js, package.json): fix Windows backslash paths being…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ Creating icon and splash screen images for all the platforms, maintaining sizes 
 PWA Asset Generator automates the image generation in a creative way. PWA Asset Generator automates the image generation in a creative way. Having [Puppeteer](https://pptr.dev) in its core enables lots of possibilities. 
 
 * Generates both icons and splash screens with optional `--icon-only` `--splash-only` `--landscape-only` and `--portrait-only` flags ✨
+
 * Updates your `manifest.json` and `index.html` files automatically for declaring generated image assets 🙌
+
 * Scrapes latest specs from Apple Human Interface guidelines website via Puppeteer to make your PWA ready for all/recent iOS devices out there 🤖
+
     * Supports offline mode and uses static spec data when things go wrong with scraping 📴
+
 * Uses Chrome browser as it’s a canvas of your fav image editor. It uses a shell HTML file as an artboard and centers your logo before taking screenshots for each resolution via Puppeteer 🤖
+
 * You can provide your source in multiple formats; a local image file, a local HTML file, a remote image or HTML file 🙌
+
     * When it’s an image source, it is centered over the background option you provide 🌅
     * When it’s an HTML source, you can go as creative as you like; position your logo, use SVG filters, use variable fonts, use gradient backgrounds, use typography and etc. Your html file is rendered on Chrome before taking screenshots for each resolution 🎨 
 

--- a/helpers/file.js
+++ b/helpers/file.js
@@ -129,6 +129,15 @@ const convertBackslashPathToSlashPath = backSlashPath => {
   return slash(backSlashPath);
 };
 
+const getRelativeImagePath = (outputFilePath, imagePath) => {
+  if (outputFilePath) {
+    return convertBackslashPathToSlashPath(
+      getRelativeFilePath(outputFilePath, imagePath),
+    );
+  }
+  return convertBackslashPathToSlashPath(imagePath);
+};
+
 const saveHtmlShell = (imagePath, options, isUrl) => {
   const imageUrl = isUrl ? imagePath : getFileUrlOfPath(imagePath);
   const htmlContent = constants.SHELL_HTML_FOR_LOGO(
@@ -143,6 +152,7 @@ const saveHtmlShell = (imagePath, options, isUrl) => {
 module.exports = {
   addHashPostfixToImages,
   convertBackslashPathToSlashPath,
+  getRelativeImagePath,
   saveHtmlShell,
   isHtmlFile,
   isImageFile,

--- a/helpers/file.js
+++ b/helpers/file.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const slash = require('slash');
 const crypto = require('crypto');
 const fileUrl = require('file-url');
 const constants = require('../config/constants');
@@ -124,6 +125,10 @@ const addHashPostfixToImages = savedImages => {
   );
 };
 
+const convertBackslashPathToSlashPath = backSlashPath => {
+  return slash(backSlashPath);
+};
+
 const saveHtmlShell = (imagePath, options, isUrl) => {
   const imageUrl = isUrl ? imagePath : getFileUrlOfPath(imagePath);
   const htmlContent = constants.SHELL_HTML_FOR_LOGO(
@@ -137,6 +142,7 @@ const saveHtmlShell = (imagePath, options, isUrl) => {
 
 module.exports = {
   addHashPostfixToImages,
+  convertBackslashPathToSlashPath,
   saveHtmlShell,
   isHtmlFile,
   isImageFile,

--- a/helpers/pwa.js
+++ b/helpers/pwa.js
@@ -8,11 +8,7 @@ const generateIconsContentForManifest = (savedImages, manifestJsonPath) => {
       image.name.startsWith(constants.MANIFEST_ICON_FILENAME_PREFIX),
     )
     .map(({ path, width, height }) => ({
-      src: manifestJsonPath
-        ? file.convertBackslashPathToSlashPath(
-            file.getRelativeFilePath(manifestJsonPath, path),
-          )
-        : file.convertBackslashPathToSlashPath(path),
+      src: file.getRelativeImagePath(manifestJsonPath, path),
       sizes: `${width}x${height}`,
       type: `image/${file.getExtension(path)}`,
     }));
@@ -26,11 +22,7 @@ const generateAppleTouchIconHtml = (savedImages, indexHtmlPath) => {
     .map(({ width, path }) =>
       constants.APPLE_TOUCH_ICON_META_HTML(
         width,
-        indexHtmlPath
-          ? file.convertBackslashPathToSlashPath(
-              file.getRelativeFilePath(indexHtmlPath, path),
-            )
-          : file.convertBackslashPathToSlashPath(path),
+        file.getRelativeImagePath(indexHtmlPath, path),
       ),
     )
     .join('');
@@ -45,11 +37,7 @@ const generateAppleLaunchImageHtml = (savedImages, indexHtmlPath) => {
       constants.APPLE_LAUNCH_SCREEN_META_HTML(
         width,
         height,
-        indexHtmlPath
-          ? file.convertBackslashPathToSlashPath(
-              file.getRelativeFilePath(indexHtmlPath, path),
-            )
-          : file.convertBackslashPathToSlashPath(path),
+        file.getRelativeImagePath(indexHtmlPath, path),
         scaleFactor,
         orientation,
       ),

--- a/helpers/pwa.js
+++ b/helpers/pwa.js
@@ -9,8 +9,10 @@ const generateIconsContentForManifest = (savedImages, manifestJsonPath) => {
     )
     .map(({ path, width, height }) => ({
       src: manifestJsonPath
-        ? file.getRelativeFilePath(manifestJsonPath, path)
-        : path,
+        ? file.convertBackslashPathToSlashPath(
+            file.getRelativeFilePath(manifestJsonPath, path),
+          )
+        : file.convertBackslashPathToSlashPath(path),
       sizes: `${width}x${height}`,
       type: `image/${file.getExtension(path)}`,
     }));
@@ -24,7 +26,11 @@ const generateAppleTouchIconHtml = (savedImages, indexHtmlPath) => {
     .map(({ width, path }) =>
       constants.APPLE_TOUCH_ICON_META_HTML(
         width,
-        indexHtmlPath ? file.getRelativeFilePath(indexHtmlPath, path) : path,
+        indexHtmlPath
+          ? file.convertBackslashPathToSlashPath(
+              file.getRelativeFilePath(indexHtmlPath, path),
+            )
+          : file.convertBackslashPathToSlashPath(path),
       ),
     )
     .join('');
@@ -39,7 +45,11 @@ const generateAppleLaunchImageHtml = (savedImages, indexHtmlPath) => {
       constants.APPLE_LAUNCH_SCREEN_META_HTML(
         width,
         height,
-        indexHtmlPath ? file.getRelativeFilePath(indexHtmlPath, path) : path,
+        indexHtmlPath
+          ? file.convertBackslashPathToSlashPath(
+              file.getRelativeFilePath(indexHtmlPath, path),
+            )
+          : file.convertBackslashPathToSlashPath(path),
         scaleFactor,
         orientation,
       ),

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "lodash.isequal": "^4.5.0",
     "lodash.uniqwith": "^4.5.0",
     "meow": "^5.0.0",
-    "puppeteer": "^1.19.0"
+    "puppeteer": "^1.19.0",
+    "slash": "^3.0.0"
   },
   "devDependencies": {
     "@jedmao/semantic-release-npm-github-config": "^1.0.6",


### PR DESCRIPTION
… added to icon and html content

Introduce the slash npm package to use in converting backslash paths generated for saved images to
slash paths, which are needed for generated html and manifest json content

fix #36