### PR TITLE
fix(meta): added disable decoding entities option to cheerio

### DIFF
--- a/src/helpers/meta.ts
+++ b/src/helpers/meta.ts
@@ -198,7 +198,7 @@ const addMetaTagsToIndexPage = async (
   }
 
   const indexHtmlFile = await file.readFile(indexHtmlFilePath);
-  const $ = cheerio.load(indexHtmlFile);
+  const $ = cheerio.load(indexHtmlFile, { decodeEntities: false });
 
   const HEAD_SELECTOR = 'head';
   const hasElement = (selector: string): boolean => {


### PR DESCRIPTION
Disabled decoding entities on cheerio as it automatically encodes url prefixes

fix #60