### PR TITLE
fix(main): fix xhtml option having no effect on module usage

### DIFF
--- a/src/helpers/meta.ts
+++ b/src/helpers/meta.ts
@@ -215,13 +215,17 @@ ${htmlMeta[meta.name]}`;
 const addMetaTagsToIndexPage = async (
   htmlMeta: HTMLMeta,
   indexHtmlFilePath: string,
+  xhtml: boolean,
 ): Promise<void> => {
   if (!(await file.isPathAccessible(indexHtmlFilePath, file.WRITE_ACCESS))) {
     throw Error(`Cannot write to index html file ${indexHtmlFilePath}`);
   }
 
   const indexHtmlFile = await file.readFile(indexHtmlFilePath);
-  const $ = cheerio.load(indexHtmlFile, { decodeEntities: false });
+  const $ = cheerio.load(indexHtmlFile, {
+    decodeEntities: false,
+    xmlMode: xhtml,
+  });
 
   const HEAD_SELECTOR = 'head';
   const hasElement = (selector: string): boolean => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,11 @@ async function generateImages(
   }
 
   if (modOptions.index) {
-    await meta.addMetaTagsToIndexPage(htmlMeta, modOptions.index);
+    await meta.addMetaTagsToIndexPage(
+      htmlMeta,
+      modOptions.index,
+      modOptions.xhtml,
+    );
     logger.success(
       `iOS meta tags are saved to index html file ${modOptions.index}`,
     );


### PR DESCRIPTION
cheerio was removing the format of the xml tags due to a missing option. Added necessary options to
keep xhtml format on the tags updated on index.html file.

fix #351