### PR TITLE
fix(browser): allow local file imports in html input

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -151,6 +151,7 @@ export default {
     '--mute-audio',
     '--no-first-run',
     '--headless',
+    '--allow-file-access-from-files'
   ],
 
   CHROME_LAUNCHER_DEBUG_PORT: 9222,


### PR DESCRIPTION
Adds `--allow-file-access-from-files` flag to the chrome launch args to allow local files to load in an html input file.

My use case for this is to import a local script from a stenciljs project so I can use custom web components in the html that is used to generate the splashscreens.