### PR TITLE
fix(puppets): use emulate instead of setViewport to preserve pixel sizes

### DIFF
--- a/src/helpers/puppets.ts
+++ b/src/helpers/puppets.ts
@@ -189,7 +189,15 @@ const saveImages = async (
 
       try {
         const page = await browser.newPage();
-        await page.setViewport({ width, height });
+        await page.emulate({
+          userAgent: constants.EMULATED_USER_AGENT,
+          viewport: {
+            width: width / scaleFactor,
+            height: height / scaleFactor,
+            deviceScaleFactor: scaleFactor,
+            isLandscape: orientation === 'landscape'
+          }
+        });
 
         if (address) {
           // Emulate dark mode media feature when html source is provided and darkMode is enabled


### PR DESCRIPTION
By using `page.emulate` instead of `page.setViewport` any set pixel dimensions in the splashscreen html will be allowed to scale instead of staying fixed, more like the behavior on an actual device. For example, the iPhone 11 Pro Max will load html at 414px × 896px but because the scale factor is 3x it will generate a 1242px × 2688px image.

This is a splashscreen with a 150px square generated using `setViewport`. The square is actually 150px, even though if this html were to load on an actual device, it would scale accordingly.
<img src="https://user-images.githubusercontent.com/15218748/92750025-adfc0a80-f354-11ea-8f68-1e066c104d59.jpg" width="400">

This is a splashscreen with the same 150px square generated using `emulate`. See how the square is scaled to 450px to be the same relative size as it would be on an actual device.
<img src="https://user-images.githubusercontent.com/15218748/92750318-f4516980-f354-11ea-8f3c-9dab4a208a42.jpg" width="400">
