### PR TITLE
feat(constant.ts): add puppeteer's "--disable-dev-shm-usage" arg as a…

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -142,6 +142,7 @@ export default {
   },
 
   CHROME_LAUNCH_ARGS: [
+    '--disable-dev-shm-usage',
     '--log-level=3', // Fatal only
     '--no-default-browser-check',
     '--disable-infobars',


### PR DESCRIPTION
… default one

Running pwa-asset-generator headless in an environment like docker / kubernetes causes a lot of
issues, since we are not able to increase shared memory, we must add puppeteer's
"--disable-dev-shm-usage" arg as a default launch arg

ref #517