### PR TITLE
fix apple icon sizes

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -177,7 +177,7 @@ export default {
 
   // Apple platform specs: https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/
   // https://web.dev/apple-touch-icon/
-  APPLE_ICON_SIZES: [180],
+  APPLE_ICON_SIZES: [180, 167, 152, 120],
 
   // Android platform specs: https://developers.google.com/web/fundamentals/web-app-manifest/#icons
   // Windows platform specs: https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps/get-started


### PR DESCRIPTION
I think for IOS need more icons, [pls, see]( https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/)



Device or context | Icon size
-- | --
iPhone | 60x60 pt (180x180 px @3x)
  | 60x60 pt (120x120 px @2x)
iPad Pro | 83.5x83.5 pt (167x167 px @2x)
iPad, iPad mini | 76x76 pt (152x152 px @2x)

