### PR TITLE
feat(main): add "--disable-dev-shm-usage" as a default chrome launch arg

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -142,6 +142,7 @@ export default {
   },
 
   CHROME_LAUNCH_ARGS: [
+    '--disable-dev-shm-usage',
     '--log-level=3', // Fatal only
     '--no-default-browser-check',
     '--disable-infobars',


### PR DESCRIPTION
Increase shared memory size of Chromium instance by adding --disable-dev-shm-usage. See
https://developers.google.com/web/tools/puppeteer/troubleshooting#tips for details.

fix #517