### PR TITLE
Update puppeteer-core to 9.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,24 +2195,6 @@
         "@types/node": "*"
       }
     },
-    "@types/puppeteer": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.2.tgz",
-      "integrity": "sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/puppeteer-core": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz",
-      "integrity": "sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==",
-      "dev": true,
-      "requires": {
-        "@types/puppeteer": "*"
-      }
-    },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -2241,9 +2223,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -3208,9 +3190,9 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
-      "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4449,9 +4431,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.847576",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.847576.tgz",
-      "integrity": "sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg=="
+      "version": "0.0.869402",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+      "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -5544,9 +5526,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -12435,18 +12417,18 @@
       "dev": true
     },
     "puppeteer-core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-7.0.1.tgz",
-      "integrity": "sha512-CIOSYtfTFbaG/li8ZJzkqPQ15tuUb9hDTfzQ/AV/kWhv1OKV/T+VzCGx1DU2CdhoEsmLBYmVb1SQ6h0eQSRuXg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-9.1.1.tgz",
+      "integrity": "sha512-zbedbitVIGhmgz0nt7eIdLsnaoVZSlNJfBivqm2w67T8LR2bU1dvnruDZ8nQO0zn++Iet7zHbAOdnuS5+H2E7A==",
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.847576",
+        "devtools-protocol": "0.0.869402",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
+        "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
         "tar-fs": "^2.0.0",
         "unbzip2-stream": "^1.3.3",
@@ -12454,9 +12436,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "meow": "9.0.0",
     "mime-types": "2.1.31",
     "progress": "2.0.3",
-    "puppeteer-core": "7.0.1",
+    "puppeteer-core": "9.1.1",
     "slash": "3.0.0"
   },
   "devDependencies": {
@@ -91,7 +91,6 @@
     "@types/lodash.uniqwith": "^4.5.6",
     "@types/mime-types": "^2.1.0",
     "@types/progress": "^2.0.3",
-    "@types/puppeteer-core": "^5.4.0",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "commitizen": "^4.1.2",

--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -1,7 +1,7 @@
 import puppeteer, {
   Browser,
-  LaunchOptions,
-  RevisionInfo,
+  PuppeteerNodeLaunchOptions,
+  BrowserFetcherRevisionInfo,
 } from 'puppeteer-core';
 import {
   launch,
@@ -32,7 +32,9 @@ const getLocalRevisionList = (): Promise<string[]> => {
   return installer.getBrowserFetcher().localRevisions();
 };
 
-const getLocalRevisionInfo = async (): Promise<RevisionInfo | undefined> => {
+const getLocalRevisionInfo = async (): Promise<
+  BrowserFetcherRevisionInfo | undefined
+> => {
   if (isPreferredBrowserRevisionInstalled()) {
     return installer.getPreferredBrowserRevisionInfo();
   }
@@ -48,10 +50,10 @@ const getLocalRevisionInfo = async (): Promise<RevisionInfo | undefined> => {
 };
 
 const getLocalBrowserInstance = async (
-  launchArgs: LaunchOptions,
+  launchArgs: PuppeteerNodeLaunchOptions,
   noSandbox: boolean,
 ): Promise<Browser> => {
-  let revisionInfo: RevisionInfo;
+  let revisionInfo: BrowserFetcherRevisionInfo;
   const localRevisionInfo = await getLocalRevisionInfo();
 
   if (localRevisionInfo) {
@@ -104,7 +106,7 @@ const getLaunchedChromeVersionInfo = (
 
 const getSystemBrowserInstance = async (
   chrome: LaunchedChrome,
-  launchArgs?: LaunchOptions,
+  launchArgs?: PuppeteerNodeLaunchOptions,
 ): Promise<Browser> => {
   const chromeVersionInfo = await getLaunchedChromeVersionInfo(chrome);
 
@@ -115,7 +117,7 @@ const getSystemBrowserInstance = async (
 };
 
 const getBrowserInstance = async (
-  launchArgs: LaunchOptions,
+  launchArgs: PuppeteerNodeLaunchOptions,
   noSandbox: boolean,
 ): Promise<{ chrome: LaunchedChrome | undefined; browser: Browser }> => {
   const LAUNCHER_CONNECTION_REFUSED_ERROR_CODE = 'ECONNREFUSED';

--- a/src/helpers/installer.ts
+++ b/src/helpers/installer.ts
@@ -1,4 +1,7 @@
-import puppeteer, { BrowserFetcher, RevisionInfo } from 'puppeteer-core';
+import puppeteer, {
+  BrowserFetcher,
+  BrowserFetcherRevisionInfo,
+} from 'puppeteer-core';
 import ProgressBar from 'progress';
 import preLogger from './logger';
 
@@ -24,11 +27,14 @@ const getBrowserFetcher = (): BrowserFetcher => {
     return browserFetcher;
   }
 
-  browserFetcher = puppeteer.createBrowserFetcher({ host: downloadHost });
+  // The next line uses a workaround for this issue: https://github.com/puppeteer/puppeteer/issues/7100
+  browserFetcher = ((puppeteer as unknown) as puppeteer.PuppeteerNode).createBrowserFetcher(
+    { host: downloadHost },
+  );
   return browserFetcher;
 };
 
-const getPreferredBrowserRevisionInfo = (): RevisionInfo => {
+const getPreferredBrowserRevisionInfo = (): BrowserFetcherRevisionInfo => {
   const revision =
     process.env.PUPPETEER_CHROMIUM_REVISION ||
     process.env.npm_config_puppeteer_chromium_revision ||
@@ -78,7 +84,7 @@ const onProgress = (downloadedBytes: number, totalBytes: number): void => {
   progressBar.tick(delta);
 };
 
-const installPreferredBrowserRevision = async (): Promise<RevisionInfo> => {
+const installPreferredBrowserRevision = async (): Promise<BrowserFetcherRevisionInfo> => {
   logger.warn(
     `Chromium is not found in module folder, gonna have to download r${revision} for you once`,
   );


### PR DESCRIPTION
This updates `puppeteer-core` to `9.1.1` (the last version that still supports node v10).

`puppeteer-core` is now natively typed, which has resulted in a few renamed interfaces and a single bug that needs a workaround :)