### PR TITLE
Allow path override of empty string

### DIFF
--- a/src/helpers/meta.ts
+++ b/src/helpers/meta.ts
@@ -25,7 +25,7 @@ const generateOutputPath = (
     isManifest ? manifestJsonPath : indexHtmlPath
   ) as string;
 
-  if (pathOverride) {
+  if (pathOverride !== undefined) {
     return `${pathOverride}/${path.parse(imagePath).base}`;
   }
 


### PR DESCRIPTION
Allows for paths in the root of the domain
e.g. in a next.js app where the output file path may be /public/foo.png
but the URL would be /foo.png

Please let me know if there's another way to achieve this that I might be missing! :)