### PR TITLE
Add iPhone 17 series to apple-fallback-data.json

### DIFF
--- a/src/config/apple-fallback-data.json
+++ b/src/config/apple-fallback-data.json
@@ -168,6 +168,54 @@
     "scaleFactor": 2
   },
   {
+    "device": "iPhone 17 Pro Max",
+    "portrait": {
+      "width": 1320,
+      "height": 2868
+    },
+    "landscape": {
+      "width": 2868,
+      "height": 1320
+    },
+    "scaleFactor": 3
+  },
+  {
+    "device": "iPhone 17 Pro",
+    "portrait": {
+      "width": 1206,
+      "height": 2622
+    },
+    "landscape": {
+      "width": 2622,
+      "height": 1206
+    },
+    "scaleFactor": 3
+  },
+  {
+    "device": "iPhone 17 Air",
+    "portrait": {
+      "width": 1260,
+      "height": 2736
+    },
+    "landscape": {
+      "width": 2736,
+      "height": 1260
+    },
+    "scaleFactor": 3
+  },
+  {
+    "device": "iPhone 17",
+    "portrait": {
+      "width": 1206,
+      "height": 2622
+    },
+    "landscape": {
+      "width": 2622,
+      "height": 1206
+    },
+    "scaleFactor": 3
+  },
+  {
     "device": "iPhone 16 Pro Max",
     "portrait": {
       "width": 1320,


### PR DESCRIPTION
## Summary
- Add iPhone 17 Pro Max, iPhone 17 Pro, iPhone 17 Air, and iPhone 17 to the Apple fallback device list
- iPhone 17 Air introduces a new unique resolution: 1260×2736 @3x
- iPhone 17, 17 Pro, and 17 Pro Max share resolutions with existing devices but are added for completeness, consistent with how the list handles other generations

## Device specs

| Device | Resolution | Scale | New resolution? |
|--------|-----------|-------|:---:|
| iPhone 17 Pro Max | 1320×2868 | 3x | No (= iPhone 16 Pro Max) |
| iPhone 17 Pro | 1206×2622 | 3x | No (= iPhone 16 Pro) |
| iPhone 17 Air | 1260×2736 | 3x | **Yes** |
| iPhone 17 | 1206×2622 | 3x | No (= iPhone 16 Pro) |

Source: [Apple iPhone 17 specs](https://www.apple.com/iphone-17/specs/), [iPhone Air specs](https://en.wikipedia.org/wiki/IPhone_Air)
